### PR TITLE
Add readers for the data used in Mustafa et al 2019 paper

### DIFF
--- a/examples/dbscan/reader.cpp
+++ b/examples/dbscan/reader.cpp
@@ -14,9 +14,11 @@
 #include <ArborX_Exception.hpp>
 
 #include <algorithm>
+#include <cassert>
 #include <fstream>
 #include <iostream>
 #include <iterator>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -76,11 +78,184 @@ std::vector<ArborX::Point> loadArborXData(std::string const &filename,
   return v;
 }
 
+std::vector<ArborX::Point> loadNGSIMData(std::string const &filename,
+                                         bool binary)
+{
+  assert(!binary);
+  std::cout << "Trying to open " << filename << " assuming NGSIM data.\n";
+  std::ifstream file(filename);
+  assert(file.good());
+
+  std::string thisWord, line;
+
+  std::vector<ArborX::Point> v;
+  int n_points = 0;
+
+  // ignore first line that contains the descriptions
+  getline(file, thisWord);
+  while (file.good() && n_points < 1000000)
+  {
+    getline(file, line);
+    std::stringstream ss(line);
+    // GVehicle_ID,Frame_ID,Total_Frames,Global_Time,Local_X,Local_Y
+    for (int i = 0; i < 6; ++i)
+      getline(ss, thisWord, ',');
+    // Global_X,Global_Y
+    getline(ss, thisWord, ',');
+    float longitude = stof(thisWord);
+    getline(ss, thisWord, ',');
+    float latitude = stof(thisWord);
+    v.emplace_back(longitude, latitude, 0.f);
+    // v_length,v_Width,v_Class,v_Vel,v_Acc,Lane_ID,O_Zone,D_Zone,Int_ID,Section_ID,Direction,Movement,Preceding,Following,Space_Headway,Time_Headway,Location
+    for (int i = 0; i < 16; ++i)
+      getline(ss, thisWord, ',');
+    getline(ss, thisWord, ',');
+    ++n_points;
+  }
+  std::cout << "done\nRead in " << v.size() << " points" << std::endl;
+  return v;
+}
+
+std::vector<ArborX::Point> loadTaxiPortoData(std::string const &filename,
+                                             bool binary)
+{
+  assert(!binary);
+  std::cout << "Trying to open " << filename << " assuming TaxiPorto data.\n";
+  FILE *fp_data = fopen(filename.c_str(), "rb");
+  assert(fp_data);
+  char line[100000];
+
+  // This function reads and segments trajectories in dataset in the following
+  // format: The first line indicates number of variables per point (I'm ignoring
+  // that and assuming 2) The second line indicates total trajectories in file
+  // (I'm ignoring that and observing how many are there by reading them). All
+  // lines that follow contains a trajectory separated by new line. The first
+  // number in the trajectory is the number of points followed by location points
+  // separated by spaces
+
+  std::vector<float> longitudes;
+  std::vector<float> latitudes;
+  std::vector<ArborX::Point> v;
+
+  int lineNo = -1;
+  int wordNo = 0;
+  int lonlatno = 100;
+
+  float thisWord;
+  while (fgets(line, sizeof(line), fp_data))
+  {
+    // std::cout << line << std::endl;
+    if (lineNo > -1)
+    {
+      char *pch;
+      char *end_str;
+      wordNo = 0;
+      lonlatno = 0;
+      pch = strtok_r(line, "\"[", &end_str);
+      while (pch != nullptr)
+      {
+        if (wordNo > 0)
+        {
+          char *pch2;
+          char *end_str2;
+
+          pch2 = strtok_r(pch, ",", &end_str2);
+
+          if (strcmp(pch2, "]") < 0 && lonlatno < 255)
+          {
+
+            thisWord = atof(pch2);
+
+            if (thisWord != 0.00000)
+            {
+              if (thisWord > -9 && thisWord < -7)
+              {
+                longitudes.push_back(thisWord);
+                // printf("lon %f",thisWord);
+                pch2 = strtok_r(nullptr, ",", &end_str2);
+                thisWord = atof(pch2);
+                if (thisWord < 42 && thisWord > 40)
+                {
+                  latitudes.push_back(thisWord);
+                  // printf(" lat %f\n",thisWord);
+
+                  lonlatno++;
+                }
+                else
+                {
+                  longitudes.pop_back();
+                }
+              }
+            }
+          }
+        }
+        pch = strtok_r(nullptr, "[", &end_str);
+        wordNo++;
+      }
+      // printf("num lonlat were %d x 2\n",lonlatno);
+    }
+    lineNo++;
+    if (lonlatno <= 0)
+    {
+      lineNo--;
+    }
+
+    // printf("Line %d\n",lineNo);
+  }
+  fclose(fp_data);
+
+  int num_points = longitudes.size();
+  assert(longitudes.size() == latitudes.size());
+  v.reserve(num_points);
+  for (unsigned int i = 0; i < num_points; ++i)
+    v.emplace_back(longitudes[i], latitudes[i], 0.f);
+
+  std::cout << "done\nRead in " << v.size() << " points" << std::endl;
+
+  return v;
+}
+
+std::vector<ArborX::Point> load3dSpatialNetworkData(std::string const &filename,
+                                                    bool binary)
+{
+  assert(!binary);
+  std::cout << "Trying to open " << filename
+            << " assuming 3dSpatialNetwork data.\n";
+  std::ifstream file(filename);
+  assert(file.good());
+
+  std::vector<ArborX::Point> v;
+
+  std::string thisWord;
+  while (file.good())
+  {
+    getline(file, thisWord, ',');
+    getline(file, thisWord, ',');
+    float longitude = stof(thisWord);
+    getline(file, thisWord, ',');
+    float latitude = stof(thisWord);
+    v.emplace_back(longitude, latitude, 0.f);
+  }
+  // really?????
+  // lon_ptr.pop_back();
+  // lat_ptr.pop_back();
+  std::cout << "done\nRead in " << v.size() << " points" << std::endl;
+
+  return v;
+}
+
 std::vector<ArborX::Point> loadData(std::string const &filename,
                                     std::string const &reader_type, bool binary)
 {
+  std::cout << "in reader" << std::endl;
   if (reader_type == "arborx")
     return loadArborXData(filename, binary);
+  else if (reader_type == "NGSIM")
+    return loadNGSIMData(filename, binary);
+  else if (reader_type == "TaxiPorto")
+    return loadTaxiPortoData(filename, binary);
+  else if (reader_type == "3dSpatialNetwork")
+    return load3dSpatialNetworkData(filename, binary);
   else
     throw std::runtime_error("Unknown reader type: \"" + reader_type + "\"");
 }


### PR DESCRIPTION
This adds the three readers used in the comparing paper.
There were some problems reading all the data in the `NGSIM` data set but they also only use the first 10^6 in the paper. I haven't yet investigated further.
Running PortoTaxi takes a long time. Not quite sure what's going on but reading the data in works.
For some reason, they seem to discard the last data point in the `3dSpatialNetwork` data set. It runs without it fine, too.