### PR TITLE
Try explicit instantiation in generated source files to speed up compilation

### DIFF
--- a/benchmarks/brute_force_vs_bvh/CMakeLists.txt
+++ b/benchmarks/brute_force_vs_bvh/CMakeLists.txt
@@ -1,3 +1,21 @@
-add_executable(ArborX_BruteForceVsBVH.exe brute_force_vs_bvh.cpp)
+set(EXPLICIT_INSTANTIATION_SOURCE_FILES)
+set(TEMPLATE_PARAMETERS 3)
+if(Kokkos_VERSION VERSION_GREATER_EQUAL 3.7)
+  list(APPEND TEMPLATE_PARAMETERS 2 4 5 6)
+endif()
+foreach(DIM ${TEMPLATE_PARAMETERS})
+  set(filename ${CMAKE_CURRENT_BINARY_DIR}/brute_force_vs_bvh_${DIM}.cpp)
+  file(WRITE ${filename}
+    "#include \"${CMAKE_CURRENT_SOURCE_DIR}/brute_force_vs_bvh_timpl.hpp\"\n"
+    "template void ArborXBenchmark::run<${DIM}>(int, int, int);\n"
+  )
+  list(APPEND EXPLICIT_INSTANTIATION_SOURCE_FILES ${filename})
+endforeach()
+
+
+add_executable(ArborX_BruteForceVsBVH.exe
+  ${EXPLICIT_INSTANTIATION_SOURCE_FILES}
+  brute_force_vs_bvh.cpp
+)
 target_link_libraries(ArborX_BruteForceVsBVH.exe ArborX::ArborX Boost::program_options)
 add_test(NAME ArborX_BruteForceVsBVH_Benchmark COMMAND ./ArborX_BruteForceVsBVH.exe)

--- a/benchmarks/brute_force_vs_bvh/brute_force_vs_bvh.cpp
+++ b/benchmarks/brute_force_vs_bvh/brute_force_vs_bvh.cpp
@@ -9,111 +9,11 @@
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
 
-#include <ArborX_BruteForce.hpp>
-#include <ArborX_HyperBox.hpp>
-#include <ArborX_HyperPoint.hpp>
-#include <ArborX_HyperSphere.hpp>
-#include <ArborX_LinearBVH.hpp>
+#include "brute_force_vs_bvh.hpp"
 
 #include <Kokkos_Core.hpp>
 
 #include <boost/program_options.hpp>
-
-using ExecutionSpace = Kokkos::DefaultExecutionSpace;
-using MemorySpace = ExecutionSpace::memory_space;
-
-template <int DIM>
-struct Dummy
-{
-  int count;
-};
-
-// Primitives are a set of points located at (i, i, i),
-// with i = 0, ..., n-1
-template <int DIM>
-struct ArborX::AccessTraits<Dummy<DIM>, ArborX::PrimitivesTag>
-{
-  using memory_space = MemorySpace;
-  using size_type = typename MemorySpace::size_type;
-  static KOKKOS_FUNCTION size_type size(Dummy<DIM> d) { return d.count; }
-  static KOKKOS_FUNCTION auto get(Dummy<DIM>, size_type i)
-  {
-    ArborX::ExperimentalHyperGeometry::Point<DIM> point;
-    for (int d = 0; d < DIM; ++d)
-      point[d] = i;
-    return point;
-  }
-};
-
-// Predicates are sphere intersections with spheres of radius i
-// centered at (i, i, i), with i = 0, ..., n-1
-template <int DIM>
-struct ArborX::AccessTraits<Dummy<DIM>, ArborX::PredicatesTag>
-{
-  using memory_space = MemorySpace;
-  using size_type = typename MemorySpace::size_type;
-  static KOKKOS_FUNCTION size_type size(Dummy<DIM> d) { return d.count; }
-  static KOKKOS_FUNCTION auto get(Dummy<DIM>, size_type i)
-  {
-    ArborX::ExperimentalHyperGeometry::Point<DIM> center;
-    for (int d = 0; d < DIM; ++d)
-      center[d] = i;
-    return attach(intersects(ArborX::ExperimentalHyperGeometry::Sphere<DIM>{
-                      center, (float)i}),
-                  i);
-  }
-};
-
-template <int DIM>
-void run(int nprimitives, int nqueries, int nrepeats)
-{
-  ExecutionSpace space{};
-  Dummy<DIM> primitives{nprimitives};
-  Dummy<DIM> predicates{nqueries};
-
-  printf("Dimension : %d\n", DIM);
-  printf("Primitives: %d\n", nprimitives);
-  printf("Predicates: %d\n", nqueries);
-  printf("Iterations: %d\n", nrepeats);
-
-  using Box = ArborX::ExperimentalHyperGeometry::Box<DIM>;
-
-  for (int i = 0; i < nrepeats; i++)
-  {
-    unsigned int out_count;
-    {
-      Kokkos::Timer timer;
-      ArborX::BasicBoundingVolumeHierarchy<MemorySpace, Box> bvh{space,
-                                                                 primitives};
-
-      Kokkos::View<int *, ExecutionSpace> indices("indices_ref", 0);
-      Kokkos::View<int *, ExecutionSpace> offset("offset_ref", 0);
-      bvh.query(space, predicates, indices, offset);
-
-      space.fence();
-      double time = timer.seconds();
-      if (i == 0)
-        printf("Collisions: %.5f\n",
-               (float)(indices.extent(0)) / (nprimitives * nqueries));
-      printf("Time BVH: %lf\n", time);
-      out_count = indices.extent(0);
-    }
-
-    {
-      Kokkos::Timer timer;
-      ArborX::BruteForce<MemorySpace, Box> brute{space, primitives};
-
-      Kokkos::View<int *, ExecutionSpace> indices("indices", 0);
-      Kokkos::View<int *, ExecutionSpace> offset("offset", 0);
-      brute.query(space, predicates, indices, offset);
-
-      space.fence();
-      double time = timer.seconds();
-      printf("Time BF: %lf\n", time);
-      ARBORX_ASSERT(out_count == indices.extent(0));
-    }
-  }
-}
 
 int main(int argc, char *argv[])
 {
@@ -143,8 +43,10 @@ int main(int argc, char *argv[])
     std::cout << desc << '\n';
     return 1;
   }
-  ARBORX_ASSERT(nprimitives > 0);
-  ARBORX_ASSERT(nqueries > 0);
+  assert(nprimitives > 0);
+  assert(nqueries > 0);
+
+  using ArborXBenchmark::run;
 
   switch (dim)
   {

--- a/benchmarks/brute_force_vs_bvh/brute_force_vs_bvh.hpp
+++ b/benchmarks/brute_force_vs_bvh/brute_force_vs_bvh.hpp
@@ -1,0 +1,18 @@
+/****************************************************************************
+ * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+namespace ArborXBenchmark
+{
+
+template <int DIM>
+void run(int nprimitives, int nqueries, int nrepeats);
+
+}

--- a/benchmarks/brute_force_vs_bvh/brute_force_vs_bvh_timpl.hpp
+++ b/benchmarks/brute_force_vs_bvh/brute_force_vs_bvh_timpl.hpp
@@ -1,0 +1,117 @@
+/****************************************************************************
+ * Copyright (c) 2017-2022 by the ArborX authors                            *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the ArborX library. ArborX is                       *
+ * distributed under a BSD 3-clause license. For the licensing terms see    *
+ * the LICENSE file in the top-level directory.                             *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <ArborX_BruteForce.hpp>
+#include <ArborX_HyperBox.hpp>
+#include <ArborX_HyperPoint.hpp>
+#include <ArborX_HyperSphere.hpp>
+#include <ArborX_LinearBVH.hpp>
+
+#include <Kokkos_Core.hpp>
+
+#include "brute_force_vs_bvh.hpp"
+
+using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+using MemorySpace = ExecutionSpace::memory_space;
+
+template <int DIM>
+struct Dummy
+{
+  int count;
+};
+
+// Primitives are a set of points located at (i, i, i),
+// with i = 0, ..., n-1
+template <int DIM>
+struct ArborX::AccessTraits<Dummy<DIM>, ArborX::PrimitivesTag>
+{
+  using memory_space = MemorySpace;
+  using size_type = typename MemorySpace::size_type;
+  static KOKKOS_FUNCTION size_type size(Dummy<DIM> d) { return d.count; }
+  static KOKKOS_FUNCTION auto get(Dummy<DIM>, size_type i)
+  {
+    ArborX::ExperimentalHyperGeometry::Point<DIM> point;
+    for (int d = 0; d < DIM; ++d)
+      point[d] = i;
+    return point;
+  }
+};
+
+// Predicates are sphere intersections with spheres of radius i
+// centered at (i, i, i), with i = 0, ..., n-1
+template <int DIM>
+struct ArborX::AccessTraits<Dummy<DIM>, ArborX::PredicatesTag>
+{
+  using memory_space = MemorySpace;
+  using size_type = typename MemorySpace::size_type;
+  static KOKKOS_FUNCTION size_type size(Dummy<DIM> d) { return d.count; }
+  static KOKKOS_FUNCTION auto get(Dummy<DIM>, size_type i)
+  {
+    ArborX::ExperimentalHyperGeometry::Point<DIM> center;
+    for (int d = 0; d < DIM; ++d)
+      center[d] = i;
+    return attach(intersects(ArborX::ExperimentalHyperGeometry::Sphere<DIM>{
+                      center, (float)i}),
+                  i);
+  }
+};
+
+template <int DIM>
+void ArborXBenchmark::run(int nprimitives, int nqueries, int nrepeats)
+{
+  ExecutionSpace space{};
+  Dummy<DIM> primitives{nprimitives};
+  Dummy<DIM> predicates{nqueries};
+
+  printf("Dimension : %d\n", DIM);
+  printf("Primitives: %d\n", nprimitives);
+  printf("Predicates: %d\n", nqueries);
+  printf("Iterations: %d\n", nrepeats);
+
+  using Box = ArborX::ExperimentalHyperGeometry::Box<DIM>;
+
+  for (int i = 0; i < nrepeats; i++)
+  {
+    [[maybe_unused]] unsigned int out_count;
+    {
+      Kokkos::Timer timer;
+      ArborX::BasicBoundingVolumeHierarchy<MemorySpace, Box> bvh{space,
+                                                                 primitives};
+
+      Kokkos::View<int *, ExecutionSpace> indices("indices_ref", 0);
+      Kokkos::View<int *, ExecutionSpace> offset("offset_ref", 0);
+      bvh.query(space, predicates, indices, offset);
+
+      space.fence();
+      double time = timer.seconds();
+      if (i == 0)
+        printf("Collisions: %.5f\n",
+               (float)(indices.extent(0)) / (nprimitives * nqueries));
+      printf("Time BVH: %lf\n", time);
+      out_count = indices.extent(0);
+    }
+
+    {
+      Kokkos::Timer timer;
+      ArborX::BruteForce<MemorySpace, Box> brute{space, primitives};
+
+      Kokkos::View<int *, ExecutionSpace> indices("indices", 0);
+      Kokkos::View<int *, ExecutionSpace> offset("offset", 0);
+      brute.query(space, predicates, indices, offset);
+
+      space.fence();
+      double time = timer.seconds();
+      printf("Time BF: %lf\n", time);
+      assert(out_count == indices.extent(0));
+    }
+  }
+}
+


### PR DESCRIPTION
on my laptop 
```
// THIS PR
cmake --build cmake-build-default --target ArborX_BruteForceVsBVH.exe  27.99s user 0.81s system 510% cpu 5.642 total
// ORIGIN
cmake --build cmake-build-default --target ArborX_BruteForceVsBVH.exe  16.49s user 0.48s system 99% cpu 17.097 total