### PR TITLE
Make non generate trees (`bvh.size() >= 2`) a precondition to use `HappyTreeFriends`

### DIFF
--- a/src/details/ArborX_DetailsHappyTreeFriends.hpp
+++ b/src/details/ArborX_DetailsHappyTreeFriends.hpp
@@ -28,12 +28,14 @@ struct HappyTreeFriends
   template <class BVH>
   static KOKKOS_FUNCTION int getRoot(BVH const &bvh)
   {
-    return (bvh.size() > 1 ? bvh.size() : 0);
+    assert(bvh.size() > 1);
+    return bvh.size();
   }
 
   template <class BVH>
   static KOKKOS_FUNCTION bool isLeaf(BVH const &bvh, int i)
   {
+    assert(bvh.size() > 1);
     assert(i >= 0 && i < 2 * (int)bvh.size() - 1);
     return i < (int)bvh.size();
   }

--- a/src/details/ArborX_DetailsTreeTraversal.hpp
+++ b/src/details/ArborX_DetailsTreeTraversal.hpp
@@ -76,7 +76,7 @@ struct TreeTraversal<BVH, Predicates, Callback, SpatialPredicateTag>
   KOKKOS_FUNCTION void operator()(OneLeafTree, int queryIndex) const
   {
     auto const &predicate = Access::get(_predicates, queryIndex);
-    auto const root = HappyTreeFriends::getRoot(_bvh);
+    auto const root = 0;
     auto const &root_bounding_volume =
         HappyTreeFriends::getBoundingVolume(_bvh, root);
     if (predicate(root_bounding_volume))
@@ -421,7 +421,7 @@ struct TreeTraversal<BVH, Predicates, Callback,
   KOKKOS_FUNCTION void operator()(OneLeafTree, int queryIndex) const
   {
     auto const &predicate = Access::get(_predicates, queryIndex);
-    auto const root = HappyTreeFriends::getRoot(_bvh);
+    auto const root = 0;
     auto const &root_bounding_volume =
         HappyTreeFriends::getBoundingVolume(_bvh, root);
     using distance_type =


### PR DESCRIPTION
Might want to add more assertions and cast to avoid warning comparison signed and unsigned integers