### PR TITLE
Keep KDOP as a "plugin" geometry

### DIFF
--- a/src/geometry/ArborX_DetailsAlgorithms.hpp
+++ b/src/geometry/ArborX_DetailsAlgorithms.hpp
@@ -425,6 +425,17 @@ struct centroid<SphereTag, Sphere>
   }
 };
 
+template <typename KDOP>
+struct centroid<KDOPTag, KDOP>
+{
+  KOKKOS_FUNCTION static auto apply(KDOP const &kdop)
+  {
+    // FIXME approximation
+    using Box = ArborX::Box;
+    return centroid<BoxTag, Box>::apply((Box)kdop);
+  }
+};
+
 } // namespace Dispatch
 
 // transformation that maps the unit cube into a new axis-aligned box

--- a/src/geometry/ArborX_DetailsAlgorithms.hpp
+++ b/src/geometry/ArborX_DetailsAlgorithms.hpp
@@ -27,7 +27,6 @@ namespace Details
 namespace Dispatch
 {
 using GeometryTraits::BoxTag;
-using GeometryTraits::KDOPTag;
 using GeometryTraits::PointTag;
 using GeometryTraits::SphereTag;
 
@@ -294,19 +293,6 @@ struct expand<BoxTag, PointTag, Box, Point>
   }
 };
 
-// expand a box to include a point
-template <typename Box, typename KDOP>
-struct expand<BoxTag, KDOPTag, Box, KDOP>
-{
-  KOKKOS_FUNCTION static void apply(Box &box, KDOP const &kdop)
-  {
-    // FIXME This is a workaround so that we can use existing conversion
-    // machinery for KDOP. In the long term, this should be replaced by a
-    // general algorithm.
-    Details::expand(box, (ArborX::Box)kdop);
-  }
-};
-
 // expand a box to include a box
 template <typename Box1, typename Box2>
 struct expand<BoxTag, BoxTag, Box1, Box2>
@@ -422,17 +408,6 @@ struct centroid<SphereTag, Sphere>
   KOKKOS_FUNCTION static auto apply(Sphere const &sphere)
   {
     return sphere.centroid();
-  }
-};
-
-template <typename KDOP>
-struct centroid<KDOPTag, KDOP>
-{
-  KOKKOS_FUNCTION static auto apply(KDOP const &kdop)
-  {
-    // FIXME approximation
-    using Box = ArborX::Box;
-    return centroid<BoxTag, Box>::apply((Box)kdop);
   }
 };
 

--- a/src/geometry/ArborX_KDOP.hpp
+++ b/src/geometry/ArborX_KDOP.hpp
@@ -304,13 +304,6 @@ KOKKOS_INLINE_FUNCTION bool intersects(KDOP<k> const &a, KDOP<k> const &b)
   return a.intersects(b);
 }
 
-template <int k>
-KOKKOS_INLINE_FUNCTION Point returnCentroid(KDOP<k> const &p)
-{
-  // FIXME approximation
-  return ArborX::Details::returnCentroid((Box)p);
-}
-
 } // namespace Experimental
 
 template <int k>

--- a/src/geometry/ArborX_KDOP.hpp
+++ b/src/geometry/ArborX_KDOP.hpp
@@ -305,18 +305,44 @@ KOKKOS_INLINE_FUNCTION bool intersects(KDOP<k> const &a, KDOP<k> const &b)
 }
 
 } // namespace Experimental
+} // namespace ArborX
+
+// expand a box to include a point
+template <typename Box, typename KDOP>
+struct ArborX::Details::Dispatch::expand<ArborX::Details::Dispatch::BoxTag,
+                                         ArborX::Details::Dispatch::KDOPTag,
+                                         Box, KDOP>
+{
+  KOKKOS_FUNCTION static void apply(Box &box, KDOP const &kdop)
+  {
+    // FIXME This is a workaround so that we can use existing conversion
+    // machinery for KDOP. In the long term, this should be replaced by a
+    // general algorithm.
+    Details::expand(box, (ArborX::Box)kdop);
+  }
+};
+
+template <typename KDOP>
+struct ArborX::Details::Dispatch::centroid<ArborX::Details::Dispatch::KDOPTag,
+                                           KDOP>
+{
+  KOKKOS_FUNCTION static auto apply(KDOP const &kdop)
+  {
+    // FIXME approximation
+    using Box = ArborX::Box;
+    return centroid<BoxTag, Box>::apply((Box)kdop);
+  }
+};
 
 template <int k>
-struct GeometryTraits::dimension<ArborX::Experimental::KDOP<k>>
+struct ArborX::GeometryTraits::dimension<ArborX::Experimental::KDOP<k>>
 {
   static constexpr int value = 3;
 };
 template <int k>
-struct GeometryTraits::tag<ArborX::Experimental::KDOP<k>>
+struct ArborX::GeometryTraits::tag<ArborX::Experimental::KDOP<k>>
 {
   using type = KDOPTag;
 };
-
-} // namespace ArborX
 
 #endif


### PR DESCRIPTION
We do not want algorithms to have everything about all geometries.  We want instead the model where if you want to use KDOP you need to include the header for it.